### PR TITLE
Enable more customization how containers are spawned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+custom_base.sh

--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ sudo -u gitlab-runner gitlab-runner register \
 
 Currently, the scripts do not provide much customization.
 However, you can adapt the functions `start_container` and `install_dependencies` to specify how Podman should spawn the containers and how to install the dependencies.
-For example, you can mount additional volumes when starting the containers.
 
-Podman supports accessing Gitlab private registries.
+Some behaviour can be tweaked by tweaked by setting the correct environment variables.
+Rename the `custom_base.template.sh` file into `custom_base.sh` to make use of the customization.
+The following variables are supported right now:
+
+* `PODMAN_RUN_ARGS`: Customize how Podman spawns the containers.
+
+Podman supports access to private Gitlab registries.
 You can set the `DOCKER_AUTH_CONFIG` variable under **Settings → CI / CD** and provide the credentials for accessing the private registry.
 Details how the variable has to look can be found under [using statically defined credentials][gitlab-static-credentials] in the Gitlab documentation.
 

--- a/base.sh
+++ b/base.sh
@@ -1,7 +1,15 @@
 # shellcheck shell=bash disable=SC2034
 
+currentDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
 # Variables defined here will be availble to all the scripts.
 
 CONTAINER_ID="runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID-$CUSTOM_ENV_CI_JOB_ID"
 IMAGE="$CUSTOM_ENV_CI_JOB_IMAGE"
 CACHE_DIR="$(dirname "${BASH_SOURCE[0]}")/../_cache/runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID"
+
+# Execute customization code
+if [ -f "${currentDir}"/custom_base.sh ]; then
+    # shellcheck source=custom_base.sh disable=SC1091
+    source "${currentDir}"/custom_base.sh
+fi

--- a/custom_base.template.sh
+++ b/custom_base.template.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Rename this file to `custom_base.sh`!
+#
+# The file contains examples how the different variables can be used.
+
+# Pass additional arguments to `podman run` in `prepare.sh`.
+# Mount additional volumes into the container or limit the CPU utilization.
+# PODMAN_RUN_ARGS[0]='--volume=/mnt:/path/in/container:z'
+# PODMAN_RUN_ARGS[1]='--cpus=1'

--- a/prepare.sh
+++ b/prepare.sh
@@ -27,8 +27,7 @@ start_container() {
         --tty \
         --name "$CONTAINER_ID" \
         --volume "$CACHE_DIR:/home/user/cache" \
-        --volume "/sccache:/sccache:z" \
-        --cpus=1 \
+        "${PODMAN_RUN_ARGS[@]}" \
         "$IMAGE"
 }
 


### PR DESCRIPTION
Introduce the PODMAN_RUN_ARGS variable to hold additional arguments for
`podman run`. It can be set in the custom_base.sh file.