### PR TITLE
Add ability to install git using yum

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -48,6 +48,8 @@ install_dependencies() {
     podman exec "$CONTAINER_ID" /bin/bash -c 'if ! type git >/dev/null 2>&1 && type dnf >/dev/null 2>&1 ; then echo "DNF based distro without git"; dnf install --setopt=install_weak_deps=False --assumeyes git; fi'
     # Install git in systems with APK (e.g., Alpine)
     podman exec "$CONTAINER_ID" /bin/bash -c 'if ! type git >/dev/null 2>&1 && type apk >/dev/null 2>&1 ; then echo "APK based distro without git"; apk add git; fi'
+    # Install git in systems with YUM (e.g., RHEL<=7)
+    podman exec "$CONTAINER_ID" /bin/bash -c 'if ! type git >/dev/null 2>&1 && type yum >/dev/null 2>&1 ; then echo "YUM based distro without git"; yum install --assumeyes git; fi'
 }
 
 echo "Running in $CONTAINER_ID"


### PR DESCRIPTION
Older RPM-based distributions like RHEL 7 and CentOS 7 use YUM as their package manager instead of DNF. I added the ability to install git using yum to prepare.sh, in order to use Docker/Podman images based on these distributions with the podman runner.