### PR TITLE
prepare.sh: Fix warning

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -23,8 +23,6 @@ start_container() {
     rm "$CACHE_DIR"/_authfile_"$CONTAINER_ID"
     podman run \
         --detach \
-        --interactive \
-        --tty \
         --name "$CONTAINER_ID" \
         --volume "$CACHE_DIR:/home/user/cache":Z \
         "${PODMAN_RUN_ARGS[@]}" \


### PR DESCRIPTION
The `--interactive --tty` arguments aren't useful if the container is running detached and result in a warning.