### PR TITLE
prepare.sh: use errtrace to trigger trap from function

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -4,7 +4,7 @@ currentDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=base.sh
 source "${currentDir}"/base.sh
 
-set -eo pipefail
+set -eEo pipefail
 
 # trap any error, and mark it as a system failure.
 trap 'exit $SYSTEM_FAILURE_EXIT_CODE' ERR


### PR DESCRIPTION
When using -e/-o errexit without the -E/-o errtrace option, trap won't
be triggered if a command fails inside a function. In this case, all
relevant commands are executed inside start_container() and
install_dependencies() functions.

When the error is properly propagated, the trap error handling actually
works and the gitlab runner will attempt to re-try to start-up the
container since it correctly detects that the job failed during the
preparation stage.

See https://stackoverflow.com/a/35800451 for more details about -e -E
interaction