### PR TITLE
Use shared cache

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -60,7 +60,7 @@ start_container() {
     podman run \
         --detach \
         --name "$CONTAINER_ID" \
-        --volume "$CACHE_DIR:/home/user/cache":Z \
+        --volume "$CACHE_DIR:/home/user/cache":z \
         "${PODMAN_RUN_ARGS[@]}" \
         "$IMAGE"\
         sleep 999999999


### PR DESCRIPTION
This will allow two concurrently running tasks to access the same cache.
From the manual:
The z option tells Podman that two containers share the volume content. As a result, Podman labels the content with a shared content label. Shared volume labels allow all containers to read/write content. The Z option tells Podman to label the content with a private unshared label.