### PR TITLE
Update link to official docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Using Podman to power your Gitlab CI pipeline
 
-**⚠️ NOTE ⚠️**: New deployments should avoid using code from this repository. Instead the official Podman support should be used <https://docs.gitlab.com/runner/executors/docker.html#use-podman-to-run-docker-commands-beta>.
+**⚠️ NOTE ⚠️**: New deployments should avoid using code from this repository. Instead the official Podman support should be used <https://docs.gitlab.com/runner/executors/docker.html#use-podman-to-run-docker-commands>.
 Old deployments should consider migrating if possible.
 
 1. [Installation and Setup](#installation-and-setup)


### PR DESCRIPTION
The link to official documentation was pointing to the `-beta` anchor, but BETA was removed in [this](https://gitlab.com/gitlab-org/gitlab-runner/-/commit/d48399acad62677e872b69fc17af727eab3f887f#c338ca065aa9f0ed63fba4215c5d445310b92ffc_680) commit.